### PR TITLE
Fix license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.5.1"
 description = "AWS CloudFormation Resources to manage Kafka"
 authors = ["John Mille <john@compose-x.io>"]
 classifiers = [
+  "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
   "Natural Language :: English",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.8",
@@ -13,7 +14,7 @@ classifiers = [
 ]
 
 readme = "README.rst"
-license = "LICENSE"
+license = "MPL-2.0"
 
 [tool.poetry.urls]
 "Source" = "https://github.com/compose-x/cfn-kafka-admin"


### PR DESCRIPTION
Hi there,

I stumbled across your package on PyPI and noticed that it was classified as "License :: Other/Proprietary License" despite being licensed as MPL 2.0. This patch fixes the package's metadata so it gets properly classified as "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)."